### PR TITLE
Update beincin.py

### DIFF
--- a/src/EPGGrabber/providers/beincin.py
+++ b/src/EPGGrabber/providers/beincin.py
@@ -3,11 +3,11 @@
 
 
 try:
-	from .__init__ import *
-except:
 	from __init__ import *
+except:
+	from .__init__ import *
 
-from .elcin import Elcinema
+from elcin import Elcinema
 import io
 import requests
 import sys


### PR DESCRIPTION
had issue with OpenATV 6.4.20220304 (2022-02-27) runing this file
root@vuuno4kse:/usr/lib/enigma2/python/Plugins/Extensions/EPGGrabber/providers# python beincin.py
Traceback (most recent call last):
  File "beincin.py", line 10, in <module>
    from .elcin import Elcinema
ValueError: Attempted relative import in non-package