### PR TITLE
Update elcinEN.py

### DIFF
--- a/src/EPGGrabber/providers/elcinEN.py
+++ b/src/EPGGrabber/providers/elcinEN.py
@@ -3,11 +3,11 @@
 
 
 try:
-	from .__init__ import *
-except:
 	from __init__ import *
+except:
+	from .__init__ import *
 
-from .elcin import Elcinema, nb_channel, headers, cprint
+from elcin import Elcinema, nb_channel, headers, cprint
 import ssl
 import requests
 import sys


### PR DESCRIPTION
had issue with OpenATV 6.4.20220304 (2022-02-27) runing this file
root@vuuno4kse:/usr/lib/enigma2/python/Plugins/Extensions/EPGGrabber/providers# python elcinEN.py
Traceback (most recent call last):
  File "elcinEN.py", line 10, in <module>
    from .elcin import Elcinema, nb_channel, headers, cprint
ValueError: Attempted relative import in non-package